### PR TITLE
Handle IO events in a separate thread

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
+name = "bytes"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
+
+[[package]]
 name = "cassowary"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -186,6 +192,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -293,6 +308,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -421,6 +446,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
+name = "socket2"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -482,8 +517,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3c786bf8134e5a3a166db9b29ab8f48134739014a3eca7bc6bfa95d673b136f"
 dependencies = [
  "autocfg",
+ "bytes",
+ "libc",
+ "mio",
+ "num_cpus",
+ "parking_lot",
  "pin-project-lite",
+ "signal-hook-registry",
+ "socket2",
+ "tokio-macros",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.15",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,6 @@ edition = "2021"
 crossterm = "0.26.1"
 eyre = "0.6.8"
 log = "0.4.17"
-tokio = "1.28.0"
+tokio = { version = "1.28.0", features = ["full"] }
 tui = "0.19.0"
 tui-logger = "0.9.1"

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -8,12 +8,13 @@ use crate::inputs::key::Key;
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum Action {
     Quit,
+    Sleep,
 }
 
 impl Action {
     /// All available actions
     pub fn iterator() -> Iter<'static, Action> {
-        static ACTIONS: [Action; 1] = [Action::Quit];
+        static ACTIONS: [Action; 2] = [Action::Quit, Action::Sleep];
         ACTIONS.iter()
     }
 
@@ -21,6 +22,7 @@ impl Action {
     pub fn keys(&self) -> &[Key] {
         match self {
             Action::Quit => &[Key::Ctrl('c'), Key::Char('q')],
+            Action::Sleep => &[Key::Char('s')]
         }
     }
 }
@@ -30,6 +32,7 @@ impl Display for Action {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let str = match self {
             Action::Quit => "Quit",
+            Action::Sleep => "Sleep",
         };
 
         write!(f, "{}", str)

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,9 +1,10 @@
-use log::{debug, warn};
+use log::{debug, error, warn};
 
 use self::actions::Actions;
 use self::state::AppState;
 use crate::app::actions::Action;
 use crate::inputs::key::Key;
+use crate::io::IoEvent;
 
 pub mod actions;
 pub mod state;
@@ -17,27 +18,42 @@ pub enum AppReturn {
 
 /// The main application, containing the state
 pub struct App {
+    /// We could dispatch an IO event
+    io_tx: tokio::sync::mpsc::Sender<IoEvent>,
     /// Contextual actions
     actions: Actions,
     /// State
+    is_loading: bool,
     state: AppState,
 }
 
 impl App {
-    #[allow(clippy::new_without_default)]
-    pub fn new() -> Self {
+    pub fn new(io_tx: tokio::sync::mpsc::Sender<IoEvent>) -> Self {
         let actions = vec![Action::Quit].into();
-        let state = AppState::initialized();
+        let is_loading = false;
+        let state = AppState::default();
 
-        Self { actions, state }
+        Self {
+            io_tx,
+            actions,
+            is_loading,
+            state,
+        }
     }
 
     /// Handle a user action
-    pub fn do_action(&mut self, key: Key) -> AppReturn {
+    pub async fn do_action(&mut self, key: Key) -> AppReturn {
         if let Some(action) = self.actions.find(key) {
             debug!("Run action [{:?}]", action);
             match action {
                 Action::Quit => AppReturn::Exit,
+                Action::Sleep => {
+                    if let Some(duration) = self.state.duration().cloned() {
+                        // Sleep is an I/O action, we dispatch on the IO channel that's run on another thread
+                        self.dispatch(IoEvent::Sleep(duration)).await
+                    }
+                    AppReturn::Continue
+                }
             }
         } else {
             warn!("No action accociated to {}", key);
@@ -46,15 +62,42 @@ impl App {
     }
 
     /// Update the app or dispatch event on tick
-    pub fn update_on_tick(&mut self) -> AppReturn {
+    pub async fn update_on_tick(&mut self) -> AppReturn {
         self.state.incr_tick();
         AppReturn::Continue
+    }
+
+    pub async fn dispatch(&mut self, action: IoEvent) {
+        // `is_loading` will be set to false again after the async action has finished in io/handler.rs
+        self.is_loading = true;
+        if let Err(e) = self.io_tx.send(action).await {
+            self.is_loading = false;
+            error!("Error from dispatch {}", e);
+        };
     }
 
     pub fn actions(&self) -> &Actions {
         &self.actions
     }
+
     pub fn state(&self) -> &AppState {
         &self.state
+    }
+
+    pub fn is_loading(&self) -> bool {
+        self.is_loading
+    }
+
+    pub fn initialized(&mut self) {
+        self.actions = vec![Action::Quit, Action::Sleep].into();
+        self.state = AppState::initialized()
+    }
+
+    pub fn loaded(&mut self) {
+        self.is_loading = false;
+    }
+
+    pub fn sleeped(&mut self) {
+        self.state.incr_sleep();
     }
 }

--- a/src/app/ui.rs
+++ b/src/app/ui.rs
@@ -32,7 +32,7 @@ where
         .split(chunks[1]);
 
     // Render body
-    let body = draw_body(false, app.state());
+    let body = draw_body(app.is_loading(), app.state());
     rect.render_widget(body, body_chunks[0]);
 
     // Render help
@@ -63,14 +63,28 @@ fn draw_title<'a>() -> Paragraph<'a> {
 }
 
 fn draw_body<'a>(loading: bool, state: &AppState) -> Paragraph<'a> {
+    let initialized_text = if state.is_initialized() {
+        "Initialized"
+    } else {
+        "Not Initialized!"
+    };
+
     let loading_text = if loading { "Loading..." } else { "" };
+    let sleep_text = if let Some(sleeps) = state.count_sleep() {
+        format!("Sleep count: {}", sleeps)
+    } else {
+        String::default()
+    };
+
     let tick_text = if let Some(ticks) = state.count_tick() {
         format!("Tick count: {}", ticks)
     } else {
         String::default()
     };
     Paragraph::new(vec![
+        Spans::from(Span::raw(initialized_text)),
         Spans::from(Span::raw(loading_text)),
+        Spans::from(Span::raw(sleep_text)),
         Spans::from(Span::raw(tick_text)),
     ])
     .style(Style::default().fg(Color::LightCyan))

--- a/src/inputs/events.rs
+++ b/src/inputs/events.rs
@@ -1,43 +1,66 @@
-use std::sync::mpsc::{channel, Receiver, RecvError, Sender};
-use std::thread;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 use std::time::Duration;
+
+use log::error;
 
 use super::key::Key;
 use super::InputEvent;
 
-/// Basic event handler wrapping crossterm input and tick event. Each event
+/// A small event handler that wrap crossterm input and tick event. Each event
 /// type is handled in its own thread and returned to a common `Receiver`
 pub struct Events {
-    rx: Receiver<InputEvent>,
-    _tx: Sender<InputEvent>,
+    rx: tokio::sync::mpsc::Receiver<InputEvent>,
+    // Need to be kept around to prevent disposing the sender side.
+    _tx: tokio::sync::mpsc::Sender<InputEvent>,
+    // To stop the loop
+    stop_capture: Arc<AtomicBool>,
 }
 
 impl Events {
     /// Constructs an new instance of `Events` with the default config.
     pub fn new(tick_rate: Duration) -> Events {
-        let (tx, rx) = channel();
+        let (tx, rx) = tokio::sync::mpsc::channel(100);
+        let stop_capture = Arc::new(AtomicBool::new(false));
 
         let event_tx = tx.clone();
-        thread::spawn(move || {
+        let event_stop_capture = stop_capture.clone();
+        tokio::spawn(async move {
             loop {
                 // poll for tick rate duration, if no event, sent tick event.
                 if crossterm::event::poll(tick_rate).unwrap() {
                     if let crossterm::event::Event::Key(key) = crossterm::event::read().unwrap() {
                         let key = Key::from(key);
-                        event_tx.send(InputEvent::Input(key)).unwrap();
+                        if let Err(err) = event_tx.send(InputEvent::Input(key)).await {
+                            error!("Oops!, {}", err);
+                        }
                     }
                 }
                 
-                event_tx.send(InputEvent::Tick).unwrap();
+                if let Err(err) = event_tx.send(InputEvent::Tick).await {
+                    error!("Oops!, {}", err);
+                }
+
+                if event_stop_capture.load(Ordering::Relaxed) {
+                    break;
+                }
             }
         });
 
-        Events { rx, _tx: tx }
+        Events {
+            rx,
+            _tx: tx,
+            stop_capture,
+        }
     }
 
     /// Attempts to read an event.
-    /// This function will block the current thread.
-    pub fn next(&self) -> Result<InputEvent, RecvError> {
-        self.rx.recv()
+    pub async fn next(&mut self) -> InputEvent {
+        self.rx.recv().await.unwrap_or(InputEvent::Tick)
+    }
+
+    /// Close
+    pub fn close(&mut self) {
+        self.stop_capture.store(true, Ordering::Relaxed)
     }
 }

--- a/src/io/handler.rs
+++ b/src/io/handler.rs
@@ -1,0 +1,57 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use eyre::Result;
+use log::{error, info};
+
+use super::IoEvent;
+use crate::app::App;
+
+/// In the IO thread, we handle IO event without blocking the UI thread
+pub struct IoAsyncHandler {
+    app: Arc<tokio::sync::Mutex<App>>,
+}
+
+impl IoAsyncHandler {
+    pub fn new(app: Arc<tokio::sync::Mutex<App>>) -> Self {
+        Self { app }
+    }
+
+    /// Handle events from separate thead
+    pub async fn handle_io_event(&mut self, io_event: IoEvent) {
+        let result = match io_event {
+            IoEvent::Initialize => self.do_initialize().await,
+            IoEvent::Sleep(duration) => self.do_sleep(duration).await,
+        };
+
+        if let Err(err) = result {
+            error!("Oops, something wrong happen: {:?}", err);
+        }
+
+        let mut app = self.app.lock().await;
+        app.loaded();
+    }
+
+    /// Dumb initialization to wait one second
+    async fn do_initialize(&mut self) -> Result<()> {
+        info!("🚀 Initialize the application");
+        let mut app = self.app.lock().await;
+        tokio::time::sleep(Duration::from_secs(1)).await;
+        app.initialized();
+        info!("👍 Application initialized");
+
+        Ok(())
+    }
+
+    /// Take a little nap
+    async fn do_sleep(&mut self, duration: Duration) -> Result<()> {
+        info!("😴 Go sleeping for {:?}...", duration);
+        tokio::time::sleep(duration).await;
+        info!("⏰ Wake up !");
+        // Notify the app for having slept
+        let mut app = self.app.lock().await;
+        app.sleeped();
+
+        Ok(())
+    }
+}

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -1,0 +1,9 @@
+use std::time::Duration;
+
+pub mod handler;
+
+#[derive(Debug, Clone)]
+pub enum IoEvent {
+    Initialize,
+    Sleep(Duration),
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,12 @@
-use std::cell::RefCell;
 use std::io::stdout;
-use std::rc::Rc;
+use std::sync::Arc;
 use std::time::Duration;
 
 use app::{App, AppReturn};
 use eyre::Result;
 use inputs::events::Events;
 use inputs::InputEvent;
+use io::IoEvent;
 use tui::backend::CrosstermBackend;
 use tui::Terminal;
 
@@ -14,8 +14,10 @@ use crate::app::ui;
 
 pub mod app;
 pub mod inputs;
+pub mod io;
 
-pub fn start_ui(app: Rc<RefCell<App>>) -> Result<()> {
+pub async fn start_ui(app: &Arc<tokio::sync::Mutex<App>>) -> Result<()> {
+    // Configure Crossterm backend for tui
     let stdout = stdout();
     crossterm::terminal::enable_raw_mode()?;
     let backend = CrosstermBackend::new(stdout);
@@ -25,26 +27,35 @@ pub fn start_ui(app: Rc<RefCell<App>>) -> Result<()> {
 
     // User event handler
     let tick_rate = Duration::from_millis(200);
-    let events = Events::new(tick_rate);
+    let mut events = Events::new(tick_rate);
+
+    // Trigger state change from Init to Initialized
+    {
+        let mut app = app.lock().await;
+        // Here we assume the the first load is a long task
+        app.dispatch(IoEvent::Initialize).await;
+    }
 
     loop {
-        let mut app = app.borrow_mut();
+        let mut app = app.lock().await;
 
         // Render
         terminal.draw(|rect| ui::draw(rect, &app))?;
 
         // Handle inputs
-        let result = match events.next()? {
-            InputEvent::Input(key) => app.do_action(key),
-            InputEvent::Tick => app.update_on_tick(),
+        let result = match events.next().await {
+            InputEvent::Input(key) => app.do_action(key).await,
+            InputEvent::Tick => app.update_on_tick().await,
         };
-
+        
         // Check if we should exit
         if result == AppReturn::Exit {
+            events.close();
             break;
         }
     }
 
+    // Restore the terminal and close application
     terminal.clear()?;
     terminal.show_cursor()?;
     crossterm::terminal::disable_raw_mode()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,28 @@
-use std::cell::RefCell;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use eyre::Result;
 use terminal_pomodoro::app::App;
+use terminal_pomodoro::io::handler::IoAsyncHandler;
+use terminal_pomodoro::io::IoEvent;
 use terminal_pomodoro::start_ui;
 
-fn main() -> Result<()> {
-    let app = Rc::new(RefCell::new(App::new()));
-    start_ui(app)?;
+#[tokio::main]
+async fn main() -> Result<()> {
+    let (sync_io_tx, mut sync_io_rx) = tokio::sync::mpsc::channel::<IoEvent>(100);
+
+    // Setup app instances to share between threads
+    let app = Arc::new(tokio::sync::Mutex::new(App::new(sync_io_tx.clone())));
+    let app_ui = Arc::clone(&app);
+
+    // Handle IO in a specifc thread
+    tokio::spawn(async move {
+        let mut handler = IoAsyncHandler::new(app);
+        while let Some(io_event) = sync_io_rx.recv().await {
+            handler.handle_io_event(io_event).await;
+        }
+    });
+
+    start_ui(&app_ui).await?;
+
     Ok(())
 }


### PR DESCRIPTION
Use Tokio to separate key inputs into its own thread.  Allow users to sleep for one second